### PR TITLE
Change type of subsystem to Option<&OsStr>.

### DIFF
--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -63,7 +63,7 @@ fn monitor(context: &libudev::Context) -> io::Result<()> {
                  event.sequence_number(),
                  event.event_type(),
                  event.syspath().to_str().unwrap_or("---"),
-                 event.subsystem().to_str().unwrap_or(""),
+                 event.subsystem().map_or("", |s| { s.to_str().unwrap_or("") }),
                  event.sysname().to_str().unwrap_or(""),
                  event.devtype().map_or("", |s| { s.to_str().unwrap_or("") }));
     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -114,10 +114,8 @@ impl<'a> Device<'a> {
     ///
     /// The subsystem name is a string that indicates which kernel subsystem the device belongs to.
     /// Examples of subsystem names are `tty`, `vtconsole`, `block`, `scsi`, and `net`.
-    pub fn subsystem(&self) -> &OsStr {
-        unsafe {
-            ::util::ptr_to_os_str_unchecked(::ffi::udev_device_get_subsystem(self.device))
-        }
+    pub fn subsystem(&self) -> Option<&OsStr> {
+        ::util::ptr_to_os_str(unsafe { ::ffi::udev_device_get_subsystem(self.device) })
     }
 
     /// Returns the kernel device name for the device.


### PR DESCRIPTION
Surprisingly, it _is_ possible for a device to belong to no subsystem.

Signed-off-by: mulhern <amulhern@redhat.com>