### PR TITLE
Replace named live-times with reference counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Libudev
 This crate provides a safe wrapper around the native `libudev` library. It applies the RAII pattern
-and Rust lifetimes to ensure safe usage of all `libudev` functionality. The RAII pattern ensures
-that all acquired resources are released when they're no longer needed, and Rust lifetimes ensure
-that resources are released in a proper order.
+to ensure safe usage of all `libudev` functionality. The RAII pattern ensures that all acquired
+resources are released when they're no longer needed.
 
 * [Documentation](http://dcuddeback.github.io/libudev-rs/libudev/)
 

--- a/examples/list_devices.rs
+++ b/examples/list_devices.rs
@@ -8,7 +8,7 @@ fn main() {
 }
 
 fn list_devices(context: &libudev::Context) -> io::Result<()> {
-    let mut enumerator = try!(libudev::Enumerator::new(&context));
+    let mut enumerator = try!(libudev::Enumerator::new(context.clone()));
 
     for device in try!(enumerator.scan_devices()) {
         println!("");

--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -37,7 +37,7 @@ fn main() {
 }
 
 fn monitor(context: &libudev::Context) -> io::Result<()> {
-    let mut monitor = try!(libudev::Monitor::new(&context));
+    let mut monitor = try!(libudev::Monitor::new(context.clone()));
 
     try!(monitor.match_subsystem_devtype("usb", "usb_device"));
     let mut socket = try!(monitor.listen());

--- a/src/device.rs
+++ b/src/device.rs
@@ -9,7 +9,7 @@ use libc::{c_char,dev_t};
 use ::context::Context;
 use ::handle::*;
 
-pub fn new(context: &Context, device: *mut ::ffi::udev_device) -> Device {
+pub fn new(context: Context, device: *mut ::ffi::udev_device) -> Device {
     Device {
         _context: context,
         device: device,
@@ -17,12 +17,12 @@ pub fn new(context: &Context, device: *mut ::ffi::udev_device) -> Device {
 }
 
 /// A structure that provides access to sysfs/kernel devices.
-pub struct Device<'a> {
-    _context: &'a Context,
+pub struct Device {
+    _context: Context,
     device: *mut ::ffi::udev_device,
 }
 
-impl<'a> Drop for Device<'a> {
+impl Drop for Device {
     fn drop(&mut self) {
         unsafe {
             ::ffi::udev_device_unref(self.device);
@@ -31,13 +31,13 @@ impl<'a> Drop for Device<'a> {
 }
 
 #[doc(hidden)]
-impl<'a> Handle<::ffi::udev_device> for Device<'a> {
+impl Handle<::ffi::udev_device> for Device {
     fn as_ptr(&self) -> *mut ::ffi::udev_device {
         self.device
     }
 }
 
-impl<'a> Device<'a> {
+impl Device {
     /// Checks whether the device has already been handled by udev.
     ///
     /// When a new device is connected to the system, udev initializes the device by setting
@@ -101,7 +101,7 @@ impl<'a> Device<'a> {
             }
 
             Some(Device {
-                _context: self._context,
+                _context: self._context.clone(),
                 device: ptr,
             })
         }
@@ -241,7 +241,7 @@ impl<'a> Device<'a> {
 
 /// Iterator over a device's properties.
 pub struct Properties<'a> {
-    _device: &'a Device<'a>,
+    _device: &'a Device,
     entry: *mut ::ffi::udev_list_entry
 }
 
@@ -291,7 +291,7 @@ impl<'a> Property<'a> {
 
 /// Iterator over a device's attributes.
 pub struct Attributes<'a> {
-    device: &'a Device<'a>,
+    device: &'a Device,
     entry: *mut ::ffi::udev_list_entry
 }
 
@@ -321,7 +321,7 @@ impl<'a> Iterator for Attributes<'a> {
 
 /// A device attribute.
 pub struct Attribute<'a> {
-    device: &'a Device<'a>,
+    device: &'a Device,
     name: &'a OsStr
 }
 

--- a/src/enumerator.rs
+++ b/src/enumerator.rs
@@ -12,20 +12,30 @@ pub use device::{Device};
 /// An Enumerator scans `/sys` for devices matching its filters. Filters are added to an Enumerator
 /// by calling its `match_*` and `nomatch_*` methods. After the filters are setup, the
 /// `scan_devices()` method finds devices in `/sys` that match the filters.
-pub struct Enumerator<'a> {
-    context: &'a Context,
+pub struct Enumerator {
+    context: Context,
     enumerator: *mut ::ffi::udev_enumerate
 }
 
-impl<'a> Drop for Enumerator<'a> {
+impl Clone for Enumerator {
+    /// Bumps reference count of `libudev` enumerator.
+    fn clone(&self) -> Self {
+        Enumerator {
+            context: self.context.clone(),
+            enumerator: unsafe { ::ffi::udev_enumerate_ref(self.enumerator) },
+        }
+    }
+}
+
+impl Drop for Enumerator {
     fn drop(&mut self) {
         unsafe { ::ffi::udev_enumerate_unref(self.enumerator) };
     }
 }
 
-impl<'a> Enumerator<'a> {
+impl Enumerator {
     /// Creates a new Enumerator.
-    pub fn new(context: &'a Context) -> ::Result<Self> {
+    pub fn new(context: Context) -> ::Result<Self> {
         let ptr = try_alloc!(unsafe { ::ffi::udev_enumerate_new(context.as_ptr()) });
 
         Ok(Enumerator {
@@ -132,7 +142,7 @@ impl<'a> Enumerator<'a> {
         }));
 
         Ok(Devices {
-            enumerator: self,
+            enumerator: self.clone(),
             entry: unsafe { ::ffi::udev_enumerate_get_list_entry(self.enumerator) }
         })
     }
@@ -140,15 +150,15 @@ impl<'a> Enumerator<'a> {
 
 
 /// Iterator over devices.
-pub struct Devices<'a> {
-    enumerator: &'a Enumerator<'a>,
+pub struct Devices {
+    enumerator: Enumerator,
     entry: *mut ::ffi::udev_list_entry
 }
 
-impl<'a> Iterator for Devices<'a> {
-    type Item = Device<'a>;
+impl Iterator for Devices {
+    type Item = Device;
 
-    fn next(&mut self) -> Option<Device<'a>> {
+    fn next(&mut self) -> Option<Device> {
         while !self.entry.is_null() {
             let syspath = Path::new(unsafe {
                 ::util::ptr_to_os_str_unchecked(::ffi::udev_list_entry_get_name(self.entry))


### PR DESCRIPTION
For cases when Rust compiler cannot infer correct life-time the mechanism of
named life-times was introduced to let programmer manually state relations
between objects. This manual tinkering may however become tiresome or even lead
to issues like #3 so it should be avoided in APIs.

This commit aims to fix issue #3 by replacing named life-times with `libudev`
reference counting. Wrappers for raw `libudev` objects will now have `Clone`
trait implemented which increases reference count. Proper order of destruction
is ensured by adequate implementation of `Drop` trait as described in comments.

Example `list_devices` was successfully tested under Valgrind.