### PR TITLE
Bind Monitor with Context

### DIFF
--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use std::os::unix::io::{AsRawFd};
 
-use libc::{c_void,c_int,c_short,c_ulong,timespec};
+use libc::{c_void,c_int,c_short,c_ulong};
 
 #[repr(C)]
 struct pollfd {
@@ -32,12 +32,11 @@ extern "C" {
 }
 
 fn main() {
-    let context = libudev::Context::new().unwrap();
-    monitor(&context).unwrap();
+    monitor().unwrap();
 }
 
-fn monitor(context: &libudev::Context) -> io::Result<()> {
-    let mut monitor = try!(libudev::Monitor::new(&context));
+fn monitor() -> io::Result<()> {
+    let mut monitor = try!(libudev::Monitor::new());
 
     try!(monitor.match_subsystem_devtype("usb", "usb_device"));
     let mut socket = try!(monitor.listen());

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -15,12 +15,12 @@ use ::handle::prelude::*;
 /// A monitor communicates with the kernel over a socket. Filtering events is performed efficiently
 /// in the kernel, and only events that match the filters are received by the socket. Filters must
 /// be setup before listening for events.
-pub struct Monitor<'a> {
-    context: &'a Context,
+pub struct Monitor {
+    context: Context,
     monitor: *mut ::ffi::udev_monitor
 }
 
-impl<'a> Drop for Monitor<'a> {
+impl Drop for Monitor {
     fn drop(&mut self) {
         unsafe {
             ::ffi::udev_monitor_unref(self.monitor);
@@ -28,10 +28,12 @@ impl<'a> Drop for Monitor<'a> {
     }
 }
 
-impl<'a> Monitor<'a> {
+impl Monitor {
     /// Creates a new `Monitor`.
-    pub fn new(context: &'a Context) -> ::Result<Self> {
+    pub fn new() -> ::Result<Self> {
         let name = CString::new("udev").unwrap();
+
+        let context = Context::new()?;
 
         let ptr = try_alloc!(unsafe {
             ::ffi::udev_monitor_new_from_netlink(context.as_ptr(), name.as_ptr())
@@ -81,7 +83,7 @@ impl<'a> Monitor<'a> {
     /// Listens for events matching the current filters.
     ///
     /// This method consumes the `Monitor`.
-    pub fn listen(self) -> ::Result<MonitorSocket<'a>> {
+    pub fn listen(self) -> ::Result<MonitorSocket> {
         try!(::util::errno_to_result(unsafe {
             ::ffi::udev_monitor_enable_receiving(self.monitor)
         }));
@@ -99,12 +101,15 @@ impl<'a> Monitor<'a> {
 /// Monitors are initially setup to receive events from the kernel via a nonblocking socket. A
 /// variant of `poll()` should be used on the file descriptor returned by the `AsRawFd` trait to
 /// wait for new events.
-pub struct MonitorSocket<'a> {
-    inner: Monitor<'a>
+pub struct MonitorSocket {
+    inner: Monitor
 }
 
+/// It is save to `Send` `MonitorSocket` as long as it or any of its constituents can not be cloned.
+unsafe impl Send for MonitorSocket {}
+
 /// Provides raw access to the monitor's socket.
-impl<'a> AsRawFd for MonitorSocket<'a> {
+impl AsRawFd for MonitorSocket {
     /// Returns the file descriptor of the monitor's socket.
     fn as_raw_fd(&self) -> RawFd {
         unsafe {
@@ -113,11 +118,11 @@ impl<'a> AsRawFd for MonitorSocket<'a> {
     }
 }
 
-impl<'a> MonitorSocket<'a> {
+impl MonitorSocket {
     /// Receives the next available event from the monitor.
     ///
     /// This method does not block. If no events are available, it returns `None` immediately.
-    pub fn receive_event<'b>(&'b mut self) -> Option<Event<'a>> {
+    pub fn receive_event<'a>(&'a mut self) -> Option<Event<'a>> {
         let device = unsafe {
             ::ffi::udev_monitor_receive_device(self.inner.monitor)
         };
@@ -126,7 +131,7 @@ impl<'a> MonitorSocket<'a> {
             None
         }
         else {
-            let device = ::device::new(self.inner.context, device);
+            let device = ::device::new(&self.inner.context, device);
 
             Some(Event { device: device })
         }


### PR DESCRIPTION
Change construction of `Monitor` so that context is created along with it. This commit fixes issue #3
as monitor and context are now naturally kept together. In addition to that because MonitorSocket is
now the only owner of context (and is not cloneable) it can be safely send between threads.

Disadvantage of such approach is that application using not only monitor will implicitly create many
contexts.