### PR TITLE
Rework and an offer for maintenance

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 
-use ::{Device, FromRaw, FromRawWithContext};
+use libc::{c_char, dev_t};
+
+use ::{Device, DeviceType, FromRaw, FromRawWithContext};
 
 /// A libudev context.
 pub struct Context {
@@ -49,6 +51,57 @@ impl Context {
 
         let ptr = try_alloc!(unsafe {
             ::ffi::udev_device_new_from_syspath(self.udev, syspath.as_ptr())
+        });
+
+        Ok(unsafe { Device::from_raw(self, ptr) })
+    }
+
+    /// Creates a device for a given device type and number.
+    pub fn device_from_devnum(&self, dev_type: DeviceType, dev_num: dev_t) -> ::Result<Device> {
+        let ptr = try_alloc!(unsafe {
+            ::ffi::udev_device_new_from_devnum(self.udev, dev_type as u8 as c_char, dev_num)
+        });
+
+        Ok(unsafe { Device::from_raw(self, ptr) })
+    }
+
+    /// Creates a device from a given subsystem and sysname.
+    pub fn device_from_subsystem_sysname(&self, subsystem: &Path, syspath: &Path) -> ::Result<Device> {
+        let subsystem = try!(::util::os_str_to_cstring(subsystem));
+        let syspath = try!(::util::os_str_to_cstring(syspath));
+
+        let ptr = try_alloc!(unsafe {
+            ::ffi::udev_device_new_from_subsystem_sysname(self.udev, subsystem.as_ptr(), syspath.as_ptr())
+        });
+
+        Ok(unsafe { Device::from_raw(self, ptr) })
+    }
+
+    /// Creates a device from a given device id.
+    ///
+    /// The device id should be in one of these formats:
+    ///
+    /// - `b8:2` - block device major:minor
+    /// - `c128:1` - char device major:minor
+    /// - `n3` - network device ifindex
+    /// - `+sound:card29` - kernel driver core subsystem:device name
+    pub fn device_from_device_id(&self, device_id: &Path) -> ::Result<Device> {
+        let device_id = try!(::util::os_str_to_cstring(device_id));
+
+        let ptr = try_alloc!(unsafe {
+            ::ffi::udev_device_new_from_device_id(self.udev, device_id.as_ptr())
+        });
+
+        Ok(unsafe { Device::from_raw(self, ptr) })
+    }
+
+    /// Creates a device from the current environment (see environ(7)).
+    ///
+    /// Each key-value pair is interpreted in the same way as if it was received in an uevent
+    /// (see udev_monitor_receive_device(3)). The keys DEVPATH, SUBSYSTEM, ACTION, and SEQNUM are mandatory.
+    pub fn device_from_environment(&self) -> ::Result<Device> {
+        let ptr = try_alloc!(unsafe {
+            ::ffi::udev_device_new_from_environment(self.udev)
         });
 
         Ok(unsafe { Device::from_raw(self, ptr) })

--- a/src/device.rs
+++ b/src/device.rs
@@ -39,6 +39,15 @@ impl FromRawWithContext<::ffi::udev_device> for Device {
     }
 }
 
+/// Device Type
+#[repr(u8)]
+pub enum DeviceType {
+    /// Block Device
+    BlockDevice = 'b' as u8,
+    /// Character Device
+    CharacterDevice = 'c' as u8,
+}
+
 impl Device {
     /// Checks whether the device has already been handled by udev.
     ///

--- a/src/device.rs
+++ b/src/device.rs
@@ -6,23 +6,21 @@ use std::str::FromStr;
 
 use libc::{c_char,dev_t};
 
-use ::context::Context;
-use ::handle::*;
+use ::{Context, FromRawWithContext};
 
-pub fn new(context: &Context, device: *mut ::ffi::udev_device) -> Device {
-    Device {
-        _context: context,
-        device: device,
+/// A structure that provides access to sysfs/kernel devices.
+pub struct Device {
+    device: *mut ::ffi::udev_device,
+    context: Context,
+}
+
+impl Clone for Device {
+    fn clone(&self) -> Device {
+        unsafe { Device::from_raw(&self.context, ::ffi::udev_device_ref(self.device)) }
     }
 }
 
-/// A structure that provides access to sysfs/kernel devices.
-pub struct Device<'a> {
-    _context: &'a Context,
-    device: *mut ::ffi::udev_device,
-}
-
-impl<'a> Drop for Device<'a> {
+impl Drop for Device {
     fn drop(&mut self) {
         unsafe {
             ::ffi::udev_device_unref(self.device);
@@ -30,14 +28,18 @@ impl<'a> Drop for Device<'a> {
     }
 }
 
-#[doc(hidden)]
-impl<'a> Handle<::ffi::udev_device> for Device<'a> {
-    fn as_ptr(&self) -> *mut ::ffi::udev_device {
-        self.device
+as_ffi!(Device, device, ::ffi::udev_device);
+
+impl FromRawWithContext<::ffi::udev_device> for Device {
+    unsafe fn from_raw(context: &Context, ptr: *mut ::ffi::udev_device) -> Device {
+        Device {
+            device: ptr,
+            context: context.clone(),
+        }
     }
 }
 
-impl<'a> Device<'a> {
+impl Device {
     /// Checks whether the device has already been handled by udev.
     ///
     /// When a new device is connected to the system, udev initializes the device by setting
@@ -96,16 +98,8 @@ impl<'a> Device<'a> {
         let ptr = unsafe { ::ffi::udev_device_get_parent(self.device) };
 
         if !ptr.is_null() {
-            unsafe {
-                ::ffi::udev_device_ref(ptr);
-            }
-
-            Some(Device {
-                _context: self._context,
-                device: ptr,
-            })
-        }
-        else {
+            Some(unsafe { Device::from_raw(&self.context, ::ffi::udev_device_ref(ptr)) })
+        } else {
             None
         }
     }
@@ -209,10 +203,10 @@ impl<'a> Device<'a> {
     ///     println!("{:?} = {:?}", property.name(), property.value());
     /// }
     /// ```
-    pub fn properties(&self) -> Properties {
+    pub fn properties<'a>(&'a self) -> Properties<'a> {
         Properties {
+            entry: unsafe { ::ffi::udev_device_get_properties_list_entry(self.device) },
             _device: self,
-            entry: unsafe { ::ffi::udev_device_get_properties_list_entry(self.device) }
         }
     }
 
@@ -230,10 +224,10 @@ impl<'a> Device<'a> {
     ///     println!("{:?} = {:?}", attribute.name(), attribute.value());
     /// }
     /// ```
-    pub fn attributes(&self) -> Attributes {
+    pub fn attributes<'a>(&'a self) -> Attributes<'a> {
         Attributes {
+            entry: unsafe { ::ffi::udev_device_get_sysattr_list_entry(self.device) },
             device: self,
-            entry: unsafe { ::ffi::udev_device_get_sysattr_list_entry(self.device) }
         }
     }
 }
@@ -241,8 +235,8 @@ impl<'a> Device<'a> {
 
 /// Iterator over a device's properties.
 pub struct Properties<'a> {
-    _device: &'a Device<'a>,
-    entry: *mut ::ffi::udev_list_entry
+    entry: *mut ::ffi::udev_list_entry,
+    _device: &'a Device,
 }
 
 impl<'a> Iterator for Properties<'a> {
@@ -291,7 +285,7 @@ impl<'a> Property<'a> {
 
 /// Iterator over a device's attributes.
 pub struct Attributes<'a> {
-    device: &'a Device<'a>,
+    device: &'a Device,
     entry: *mut ::ffi::udev_list_entry
 }
 
@@ -321,7 +315,7 @@ impl<'a> Iterator for Attributes<'a> {
 
 /// A device attribute.
 pub struct Attribute<'a> {
-    device: &'a Device<'a>,
+    device: &'a Device,
     name: &'a OsStr
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -2,6 +2,7 @@ use std::str;
 
 use std::ffi::{CStr,OsStr};
 use std::path::Path;
+use std::ptr;
 use std::str::FromStr;
 
 use libc::{c_char,dev_t};
@@ -110,6 +111,31 @@ impl Device {
             Some(unsafe { Device::from_raw(&self.context, ::ffi::udev_device_ref(ptr)) })
         } else {
             None
+        }
+    }
+
+    /// Returns the parent of the device with the matching subsystem and devtype if any.
+    pub fn parent_with_subsystem(&self, subsystem: &Path) -> ::Result<Option<Device>> {
+        let subsystem = try!(::util::os_str_to_cstring(subsystem));
+        let ptr = unsafe { ::ffi::udev_device_get_parent_with_subsystem_devtype(self.device, subsystem.as_ptr(), ptr::null()) };
+
+        if !ptr.is_null() {
+            Ok(Some(unsafe { Device::from_raw(&self.context, ::ffi::udev_device_ref(ptr)) }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Returns the parent of the device with the matching subsystem and devtype if any.
+    pub fn parent_with_subsystem_devtype(&self, subsystem: &Path, devtype: &Path) -> ::Result<Option<Device>> {
+        let subsystem = try!(::util::os_str_to_cstring(subsystem));
+        let devtype = try!(::util::os_str_to_cstring(devtype));
+        let ptr = unsafe { ::ffi::udev_device_get_parent_with_subsystem_devtype(self.device, subsystem.as_ptr(), devtype.as_ptr()) };
+
+        if !ptr.is_null() {
+            Ok(Some(unsafe { Device::from_raw(&self.context, ::ffi::udev_device_ref(ptr)) }))
+        } else {
+            Ok(None)
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,8 +14,11 @@ pub type Result<T> = StdResult<T,Error>;
 /// Types of errors that occur in libudev.
 #[derive(Debug,Clone,Copy,PartialEq,Eq)]
 pub enum ErrorKind {
+    /// Allocation failed
     NoMem,
+    /// Invalid arguments
     InvalidInput,
+    /// I/O Error
     Io(io::ErrorKind)
 }
 

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,7 +1,0 @@
-pub mod prelude {
-    pub use super::Handle;
-}
-
-pub trait Handle<T> {
-    fn as_ptr(&self) -> *mut T;
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ extern crate libudev_sys as ffi;
 extern crate libc;
 
 pub use context::Context;
-pub use device::{Device, Properties, Property, Attributes, Attribute};
+pub use device::{Device, DeviceType, Properties, Property, Attributes, Attribute};
 pub use enumerator::{Enumerator, Devices};
 pub use error::{Result, Error, ErrorKind};
 pub use monitor::{MonitorBuilder, MonitorSocket, EventType, Event};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 extern crate libudev_sys as ffi;
 extern crate libc;
 
-pub use context::{Context};
-pub use device::{Device,Properties,Property,Attributes,Attribute};
-pub use enumerator::{Enumerator,Devices};
-pub use error::{Result,Error,ErrorKind};
-pub use monitor::{Monitor,MonitorSocket,EventType,Event};
+pub use context::Context;
+pub use device::{Device, Properties, Property, Attributes, Attribute};
+pub use enumerator::{Enumerator, Devices};
+pub use error::{Result, Error, ErrorKind};
+pub use monitor::{MonitorBuilder, MonitorSocket, EventType, Event};
 
 macro_rules! try_alloc {
     ($exp:expr) => {{
@@ -19,11 +19,36 @@ macro_rules! try_alloc {
     }}
 }
 
+pub trait AsRaw<T: 'static> {
+    fn as_raw(&self) -> *mut T;
+    fn into_raw(self) -> *mut T;
+}
+
+pub trait FromRaw<T: 'static> {
+    unsafe fn from_raw(ptr: *mut T) -> Self;
+}
+
+pub trait FromRawWithContext<T: 'static> {
+    unsafe fn from_raw(context: &Context, ptr: *mut T) -> Self;
+}
+
+macro_rules! as_ffi {
+    ($struct_:ident, $field:ident, $type_:ty) => {
+        impl $crate::AsRaw<$type_> for $struct_ {
+            fn as_raw(&self) -> *mut $type_ {
+                self.$field
+            }
+
+            fn into_raw(self) -> *mut $type_ {
+                self.$field
+            }
+        }
+    }
+}
+
 mod context;
 mod device;
 mod enumerator;
 mod error;
 mod monitor;
-
-mod handle;
 mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,9 @@
+//!
+//! libudev Bindings for Rust
+//!
+
+#![warn(missing_docs)]
+
 extern crate libudev_sys as ffi;
 extern crate libc;
 
@@ -19,16 +25,44 @@ macro_rules! try_alloc {
     }}
 }
 
+/// Receive the underlying raw pointer
 pub trait AsRaw<T: 'static> {
+    /// Get a reference of the underlying struct.
+    ///
+    /// The reference count will not be increased.
     fn as_raw(&self) -> *mut T;
+    /// Convert the object into the underlying pointer.
+    ///
+    /// You are responsible for freeing the object.
     fn into_raw(self) -> *mut T;
 }
 
+/// Convert from a raw pointer
 pub trait FromRaw<T: 'static> {
+    /// Create an object from a given raw pointer.
+    ///
+    /// The reference count will not be increased, be sure not to free this pointer.
+    ///
+    /// ## Unsafety
+    ///
+    /// The pointer has to be a valid reference to the expected underlying udev-struct or undefined
+    /// behaviour might occur.
     unsafe fn from_raw(ptr: *mut T) -> Self;
 }
 
+/// Convert from a raw pointer and the matching context
 pub trait FromRawWithContext<T: 'static> {
+    /// Create an object from a given raw pointer and the matching context.
+    ///
+    /// The reference count will not be increased, be sure not to free this pointer.
+    ///
+    /// ## Unsafety
+    ///
+    /// The pointer has to be a valid reference to the expected underlying udev-struct or undefined
+    /// behaviour might occur.
+    ///
+    /// If the context does not match the context that was used to create the given pointer
+    /// undefined behaviour including use-after-free segfaults might occur.
     unsafe fn from_raw(context: &Context, ptr: *mut T) -> Self;
 }
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -144,11 +144,10 @@ impl AsRawFd for MonitorSocket {
     }
 }
 
-impl MonitorSocket {
-    /// Receives the next available event from the monitor.
-    ///
-    /// This method does not block. If no events are available, it returns `None` immediately.
-    pub fn receive_event(&mut self) -> Option<Event> {
+impl Iterator for MonitorSocket {
+    type Item = Event;
+    
+    fn next(&mut self) -> Option<Event> {
         let ptr = unsafe {
             ::ffi::udev_monitor_receive_device(self.inner.monitor)
         };


### PR DESCRIPTION
Hey there @dcuddeback,

I am responsible for issue #12 and I need to use your library for https://github.com/Smithay/smithay, which I develop together with the original author @vberger.
Because you sadly don't seem to respond anymore and have abandoned this library, I went ahead, forked it and added a bunch of features.

Namely I fixed #12 and this PR also supersedes what #15 and #13 wanted to achieve by using udev's own ref-counting mechanism. It also brings the bindings closer to completion by adding more device constructors.

I offer you to take over maintenance of this crate as long as you can see these features getting merged. There are no other good names on crates.io available and we really do not need another udev-binding crate, your work was already laying a really solid foundation. I just need to way to better integrate it with my libinput bindings (over at the rusty-desktop organisation) and smithay.

I do not want to take control of this repository, I just offer my help for a very useful project and hope to avoid doing a real fork.

Greetings,
Victor