### PR TITLE
Use PhantomData to ensure Context isn't dropped while in use

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -35,13 +35,13 @@ impl Context {
     ///
     /// The `syspath` parameter should be a path to the device file within the `sysfs` file system,
     /// e.g., `/sys/devices/virtual/tty/tty0`.
-    pub fn device_from_syspath(&self, syspath: &Path) -> ::Result<Device> {
+    pub fn device_from_syspath<'a>(&'a self, syspath: &Path) -> ::Result<Device<'a>> {
         let syspath = try!(::util::os_str_to_cstring(syspath));
 
         let ptr = try_alloc!(unsafe {
             ::ffi::udev_device_new_from_syspath(self.udev, syspath.as_ptr())
         });
 
-        Ok(::device::new(self, ptr))
+        Ok(::device::new(ptr))
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -12,15 +12,15 @@ use ::handle::*;
 
 pub fn new<'a>(_context: &'a Context, device: *mut ::ffi::udev_device) -> Device<'a> {
     Device {
+        context: PhantomData,
         device: device,
-        phantom: PhantomData,
     }
 }
 
 /// A structure that provides access to sysfs/kernel devices.
 pub struct Device<'a> {
+    context: PhantomData<&'a Context>,
     device: *mut ::ffi::udev_device,
-    phantom: PhantomData<&'a ()>,
 }
 
 impl<'a> Drop for Device<'a> {
@@ -102,8 +102,8 @@ impl<'a> Device<'a> {
             }
 
             Some(Device {
+                context: PhantomData,
                 device: ptr,
-                phantom: PhantomData,
             })
         }
         else {
@@ -212,8 +212,8 @@ impl<'a> Device<'a> {
     /// ```
     pub fn properties(&self) -> Properties {
         Properties {
+            device: PhantomData,
             entry: unsafe { ::ffi::udev_device_get_properties_list_entry(self.device) },
-            phantom: PhantomData,
         }
     }
 
@@ -242,8 +242,8 @@ impl<'a> Device<'a> {
 
 /// Iterator over a device's properties.
 pub struct Properties<'a> {
+    device: PhantomData<&'a Device<'a>>,
     entry: *mut ::ffi::udev_list_entry,
-    phantom: PhantomData<&'a ()>,
 }
 
 impl<'a> Iterator for Properties<'a> {

--- a/src/device.rs
+++ b/src/device.rs
@@ -10,7 +10,7 @@ use libc::{c_char,dev_t};
 use ::context::Context;
 use ::handle::*;
 
-pub fn new<'a>(_context: &'a Context, device: *mut ::ffi::udev_device) -> Device<'a> {
+pub fn new<'a>(device: *mut ::ffi::udev_device) -> Device<'a> {
     Device {
         context: PhantomData,
         device: device,

--- a/src/device.rs
+++ b/src/device.rs
@@ -252,7 +252,8 @@ impl<'a> Iterator for Properties<'a> {
     fn next(&mut self) -> Option<Property<'a>> {
         if self.entry.is_null() {
             None
-        } else {
+        }
+        else {
             let name = unsafe { ::util::ptr_to_os_str_unchecked(::ffi::udev_list_entry_get_name(self.entry)) };
             let value = unsafe { ::util::ptr_to_os_str_unchecked(::ffi::udev_list_entry_get_value(self.entry)) };
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -126,7 +126,7 @@ impl<'a> MonitorSocket<'a> {
             None
         }
         else {
-            let device = ::device::new(self.inner.context, device);
+            let device = ::device::new(device);
 
             Some(Event { device: device })
         }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -4,11 +4,11 @@ use std::ptr;
 use std::ffi::{CString,OsStr};
 use std::ops::Deref;
 use std::os::unix::io::{RawFd,AsRawFd};
+use std::marker::PhantomData;
 
 use ::context::{Context};
 use ::device::{Device};
 use ::handle::prelude::*;
-
 
 /// Monitors for device events.
 ///
@@ -16,7 +16,7 @@ use ::handle::prelude::*;
 /// in the kernel, and only events that match the filters are received by the socket. Filters must
 /// be setup before listening for events.
 pub struct Monitor<'a> {
-    context: &'a Context,
+    context: PhantomData<&'a Context>,
     monitor: *mut ::ffi::udev_monitor
 }
 
@@ -38,7 +38,7 @@ impl<'a> Monitor<'a> {
         });
 
         Ok(Monitor {
-            context: context,
+            context: PhantomData,
             monitor: ptr
         })
     }


### PR DESCRIPTION
Until now, the code kept some unused references to the udev Context structure, to ensure it's not prematurely dropped while the Device objects are alive.

This pull request replaces that usage with the `PhantomData` marker trait, which ensures the lifetime of the Context contains the lifetimes of the child Devices.