### PR TITLE
Implement Clone for Context

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -16,6 +16,16 @@ impl Drop for Context {
     }
 }
 
+impl Clone for Context {
+    fn clone(&self) -> Self {
+        let udev = unsafe {
+            ::ffi::udev_ref(self.udev)
+        };
+
+        Self { udev }
+    }
+}
+
 #[doc(hidden)]
 impl Handle<::ffi::udev> for Context {
     fn as_ptr(&self) -> *mut ::ffi::udev {


### PR DESCRIPTION
The `udev_ref` function can be used to clone a Context. When all the Contexts are dropped, the reference count goes down to 0 and the object is freed.