### PR TITLE
Wrap syspath, devpath and sysname with Option

### DIFF
--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -62,9 +62,9 @@ fn monitor(context: &libudev::Context) -> io::Result<()> {
         println!("{}: {} {} (subsystem={}, sysname={}, devtype={})",
                  event.sequence_number(),
                  event.event_type(),
-                 event.syspath().to_str().unwrap_or("---"),
+                 event.syspath().map_or("", |s| { s.to_str().unwrap_or("") }),
                  event.subsystem().map_or("", |s| { s.to_str().unwrap_or("") }),
-                 event.sysname().to_str().unwrap_or(""),
+                 event.sysname().map_or("", |s| { s.to_str().unwrap_or("") }),
                  event.devtype().map_or("", |s| { s.to_str().unwrap_or("") }));
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -65,9 +65,9 @@ impl<'a> Device<'a> {
     /// The path is an absolute path and includes the sys mount point. For example, the syspath for
     /// `tty0` could be `/sys/devices/virtual/tty/tty0`, which includes the sys mount point,
     /// `/sys`.
-    pub fn syspath(&self) -> &Path {
-        Path::new(unsafe {
-            ::util::ptr_to_os_str_unchecked(::ffi::udev_device_get_syspath(self.device))
+    pub fn syspath(&self) -> Option<&Path> {
+        ::util::ptr_to_os_str(unsafe { ::ffi::udev_device_get_syspath(self.device) }).map(|path| {
+            Path::new(path)
         })
     }
 
@@ -75,10 +75,8 @@ impl<'a> Device<'a> {
     ///
     /// The path does not contain the sys mount point, but does start with a `/`. For example, the
     /// devpath for `tty0` could be `/devices/virtual/tty/tty0`.
-    pub fn devpath(&self) -> &OsStr {
-        unsafe {
-            ::util::ptr_to_os_str_unchecked(::ffi::udev_device_get_devpath(self.device))
-        }
+    pub fn devpath(&self) -> Option<&OsStr> {
+        ::util::ptr_to_os_str(unsafe { ::ffi::udev_device_get_devpath(self.device) })
     }
 
     /// Returns the path to the device node belonging to the device.
@@ -123,10 +121,8 @@ impl<'a> Device<'a> {
     /// The sysname is a string that differentiates the device from others in the same subsystem.
     /// For example, `tty0` is the sysname for a TTY device that differentiates it from others,
     /// such as `tty1`.
-    pub fn sysname(&self) -> &OsStr {
-        unsafe {
-            ::util::ptr_to_os_str_unchecked(::ffi::udev_device_get_sysname(self.device))
-        }
+    pub fn sysname(&self) -> Option<&OsStr> {
+        ::util::ptr_to_os_str(unsafe { ::ffi::udev_device_get_sysname(self.device) })
     }
 
     /// Returns the instance number of the device.


### PR DESCRIPTION
These methods aren't guaranteed to return a valid string pointer, they can be null.
From the libudev documentation:
```
       On success, udev_device_get_syspath(), udev_device_get_sysname(),
       udev_device_get_sysnum(), udev_device_get_devpath(),
       udev_device_get_devnode(), udev_device_get_devtype(),
       udev_device_get_subsystem(), udev_device_get_driver() and
       udev_device_get_action() return a pointer to a constant string that
       describes the requested property. The lifetime of this string is bound
       to the device it was requested on. On failure, each function may return
       NULL.
```

#### Concrete example:
```rust
fn main() {
  let context = libudev::Context::new().unwrap();
  // Open the root SATA controller (system-specific path, use `lspci`)
  let dev = context
    .device_from_syspath(std::path::Path::new("/sys/devices/pci0000:00/0000:00:1f.2/ata1"))
    .unwrap();
  println!("syspath: {:?}", dev.syspath());
  println!("subsystem: {:?}", dev.subsystem());
}
```

```
$ cargo run
...
syspath: "/sys/devices/pci0000:00/0000:00:1f.2/ata1"
subsystem: None
```

The gotten device is indeed valid, but returns None on `.subsystem()`. Before this PR, the code would crash.

This does unfortunately change the API quite significantly.
EDIT: Hold on, I'll fix the examples.

